### PR TITLE
Hide navigator

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -784,6 +784,7 @@
       sshpre.mt-2(language="js").
         locale:             [String],  default: 'en'
         hideViewSelector:   [Boolean], default: false
+        hideNavigator:      [Boolean], default: false
         hideWeekends:       [Boolean], default: false
         disableViews:       [Array],   default: []
         defaultView:        [String],  default: 'week'
@@ -845,6 +846,11 @@
           p.
             When set to true, the top view selector will disappear.#[br]
             You can still navigate from a view to another by clicking a cell (narrower view) or the view title (broader view).
+        li
+          code.mr-2 hideNavigator
+          span.code [Boolean], default: false
+          p.
+            When set to true, the top view date navigator will disappear.#[br]
         li
           code.mr-2 hideWeekends
           span.code [Boolean], default: false
@@ -1085,6 +1091,8 @@
         a(href="#release-notes") Release Notes
         a(name="release-notes")
 
+      div
+        | #[strong Version 1.17.1] Allow hiding of navigator
       div
         | #[strong Version 1.17.0] Allow overriding time cells &amp; title
       div

--- a/src/components/vue-cal/cell.vue
+++ b/src/components/vue-cal/cell.vue
@@ -102,9 +102,7 @@ export default {
           }
         })
         if (!split3) simultaneous = 2
-      }
-
-      else if (simultaneous === 2) {
+      } else if (simultaneous === 2) {
         const otherEvent = this.events.find(e => e.id === Object.keys(event.simultaneous)[0])
 
         if (Object.keys(otherEvent.overlapping).length && Object.keys(otherEvent.overlapped).length) {

--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -3,7 +3,7 @@
     .vuecal__header
       ul.vuecal__flex.vuecal__menu(v-if="!hideViewSelector")
         li(:class="{ active: view.id === id }" v-for="(v, id) in views" v-if="v.enabled" @click="switchView(id)") {{ v.label }}
-      .vuecal__title
+      .vuecal__title(v-if="!hideNavigator")
         .vuecal__arrow.vuecal__arrow--prev(@click="previous")
           slot(name="arrowPrev")
             i.angle
@@ -53,6 +53,10 @@ export default {
       default: 'en'
     },
     hideViewSelector: {
+      type: Boolean,
+      default: false
+    },
+    hideNavigator: {
       type: Boolean,
       default: false
     },


### PR DESCRIPTION
Added an option to hide the date navigator. Default: False.

Updated documentation for it.