### PR TITLE
Fix script tag installation documentation

### DIFF
--- a/src/documentation.vue
+++ b/src/documentation.vue
@@ -140,7 +140,7 @@
     &lt;head&gt;
       ...
       &lt;script src="https://unpkg.com/vue/"&gt;&lt;/script&gt;
-      &lt;script src="https://unpkg.com/vue-cal/"&gt;&lt;/script&gt;
+      &lt;script src="https://unpkg.com/vue-cal"&gt;&lt;/script&gt;
       &lt;link href="https://unpkg.com/vue-cal/dist/vuecal.css" rel="stylesheet"&gt;
     &lt;/head&gt;
 


### PR DESCRIPTION
unpkg does not redirect to the script if there is a trailing slash. ie, should be this:

https://unpkg.com/vue-cal

instead of:

https://unpkg.com/vue-cal/