### PR TITLE
Fix horizontal scroll bar shown on view transition

### DIFF
--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -1200,6 +1200,11 @@ $weekdays-headings-height: 2.8em;
   opacity: 0;
 }
 
+// Prevent the above translateX from causing a horizontal scroll bar
+.vuecal__body {
+  overflow-x: hidden;
+}
+
 .slide-fade--left-leave-active,
 .slide-fade--right-leave-active {position: absolute;height: 100%;}
 .vuecal__title .slide-fade--left-leave-active,


### PR DESCRIPTION
This change hides overflow-x content for the calendar body. The
15px translateX during view transition was causing a horizontal
scroll bar because the body content became 15px wider than the
body when it was translated to the side.

Fixes #48

Here's an 'after' video (see #48 for the 'before'):

![vue-cal-horizontal-scroll-bar-on-view-change-after optimized](https://user-images.githubusercontent.com/1728528/52830182-0fd78e00-30a6-11e9-82b2-be9b2026fec7.gif)
