### PR TITLE
Plural year translation

### DIFF
--- a/src/components/vue-cal/i18n/no.json
+++ b/src/components/vue-cal/i18n/no.json
@@ -1,7 +1,7 @@
 {
   "weekDays": ["Mandag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lørdag", "Søndag"],
   "months": ["Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"],
-  "years": "År",
+  "years": "Velg år",
   "year": "År",
   "month": "Måned",
   "week": "Uke",


### PR DESCRIPTION
We don't have plural form for years in Norway, but have change it to "Choose year".