### PR TITLE
reject creating event in onEventCreate

### DIFF
--- a/src/components/vue-cal/event-utils.js
+++ b/src/components/vue-cal/event-utils.js
@@ -58,7 +58,10 @@ export const createAnEvent = (dateTime, eventOptions, vuecal) => {
   }
 
   if (typeof vuecal.onEventCreate === 'function') {
-    vuecal.onEventCreate(event, () => deleteAnEvent(event, vuecal))
+    let canAddEvent = vuecal.onEventCreate(event, function () {
+      return deleteAnEvent(event, vuecal)
+    })
+    if (canAddEvent === false) return
   }
 
   // Check if event is a multiple day event and update days count.


### PR DESCRIPTION
If we want to reject creating an event when the user clicked to add event we couldn't do it.
But now we can return false to reject adding the event to the calendar.

_there is deleteFunction in onCreateEvent, but functionality is differnt. deleteFunction works when onCreateEvent finished and event added to the calendar then the user can call it to delete the event._