### PR TITLE
Fixed typo from literal class to prop class;

### DIFF
--- a/src/views/documentation-v2.vue
+++ b/src/views/documentation-v2.vue
@@ -1938,7 +1938,7 @@
              :disable-views="['years', 'year', 'month']"
              hide-weekends&gt;
       &lt;template v-slot:time-cell="{ hours, minutes }"&gt;
-        &lt;div class="{ line: true, hours: !minutes }"&gt;
+        &lt;div :class="{ line: true, hours: !minutes }"&gt;
           &lt;strong v-if="!minutes" style="font-size: 15px"&gt;{{ '\{\{ hours \}\}' }}&lt;/strong&gt;
           &lt;span v-else style="font-size: 11px"&gt;{{ '\{\{ minutes \}\}' }}&lt;/span&gt;
         &lt;/div&gt;


### PR DESCRIPTION
v-slot for time-cell had typo suggesting we were not passing in the
params to the class prop but using them literally;