### PR TITLE
Maintains .line:before and inits line-content span

### DIFF
--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -54,7 +54,8 @@
             .vuecal__time-column(v-if="hasTimeColumn")
               .vuecal__time-cell(v-for="(cell, i) in timeCells" :key="i" :style="`height: ${timeCellHeight}px`")
                 slot(name="time-cell" :hours="cell.hours" :minutes="cell.minutes")
-                  span.line {{ cell.label }}
+                  span.line  {{ }}
+                  span.line-content {{ cell.label }}
             .vuecal__flex.vuecal__week-numbers(v-if="showWeekNumbers && view.id === 'month'" column)
               .vuecal__flex.vuecal__week-number-cell(v-for="i in 6" :key="i" grow)
                 slot(name="week-number-cell" :week="getWeekNumber(i - 1)") {{ getWeekNumber(i - 1) }}


### PR DESCRIPTION
Second new span so direct content of time-cell can be manipulated
via css.