### PR TITLE
Adds weekday-renderer slot for header edits

### DIFF
--- a/src/components/vue-cal/header.vue
+++ b/src/components/vue-cal/header.vue
@@ -30,8 +30,8 @@
     :week-days="weekDays"
     :transition-direction="transitionDirection"
     :switch-to-narrower-view="switchToNarrowerView")
-    template(v-slot:weekday-renderer="{ heading }")
-      slot(name="weekday-renderer" :heading="heading")
+    template(v-slot:weekday-renderer="{ heading, view }")
+      slot(name="weekday-renderer" :heading="heading" :view="view")
 
   //- Sticky split-days headers on day view only.
   transition(:name="`slide-fade--${transitionDirection}`")

--- a/src/components/vue-cal/header.vue
+++ b/src/components/vue-cal/header.vue
@@ -29,8 +29,10 @@
     :view="viewProps.view"
     :week-days="weekDays"
     :transition-direction="transitionDirection"
-    :switch-to-narrower-view="switchToNarrowerView"
-  )
+    :switch-to-narrower-view="switchToNarrowerView")
+    template(v-slot:weekday-renderer="{ heading }")
+      slot(name="weekday-renderer" :heading="heading")
+
   //- Sticky split-days headers on day view only.
   transition(:name="`slide-fade--${transitionDirection}`")
     .vuecal__flex.vuecal__split-days-headers(v-if="viewProps.view.id === 'day' && $parent.hasSplits && options.stickySplitLabels && !options.minSplitWidth")

--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -16,6 +16,8 @@
         span.default {{ texts.today }}
     template(v-slot:title)
       slot(name="title" :title="viewTitle" :view="view") {{ viewTitle }}
+    template(v-slot:weekday-renderer="{ heading }")
+      slot(name="weekday-renderer" :heading="heading")
 
   .vuecal__flex.vuecal__body(v-if="!hideBody" grow)
     transition(:name="`slide-fade--${transitionDirection}`" :appear="transitions")
@@ -73,6 +75,8 @@
                 :week-days="weekDays"
                 :switch-to-narrower-view="switchToNarrowerView"
                 :style="contentMinWidth ? `min-width: ${contentMinWidth}px` : ''")
+                template(v-slot:weekday-renderer="{ heading }")
+                  slot(name="weekday-renderer" :heading="heading")
               .vuecal__flex.vuecal__split-days-headers(v-else-if="hasSplits && stickySplitLabels && minSplitWidth"
                 :style="contentMinWidth ? `min-width: ${contentMinWidth}px` : ''")
                 .day-split-header(v-for="(split, i) in splitDays" :key="i" :class="split.class || false") {{ split.label }}

--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -16,8 +16,8 @@
         span.default {{ texts.today }}
     template(v-slot:title)
       slot(name="title" :title="viewTitle" :view="view") {{ viewTitle }}
-    template(v-slot:weekday-renderer="{ heading }")
-      slot(name="weekday-renderer" :heading="heading")
+    template(v-slot:weekday-renderer="{ heading, view }")
+      slot(name="weekday-renderer" :heading="heading" :view="view")
 
   .vuecal__flex.vuecal__body(v-if="!hideBody" grow)
     transition(:name="`slide-fade--${transitionDirection}`" :appear="transitions")
@@ -75,8 +75,8 @@
                 :week-days="weekDays"
                 :switch-to-narrower-view="switchToNarrowerView"
                 :style="contentMinWidth ? `min-width: ${contentMinWidth}px` : ''")
-                template(v-slot:weekday-renderer="{ heading }")
-                  slot(name="weekday-renderer" :heading="heading")
+                template(v-slot:weekday-renderer="{ heading, view }")
+                  slot(name="weekday-renderer" :heading="heading" :view="view")
               .vuecal__flex.vuecal__split-days-headers(v-else-if="hasSplits && stickySplitLabels && minSplitWidth"
                 :style="contentMinWidth ? `min-width: ${contentMinWidth}px` : ''")
                 .day-split-header(v-for="(split, i) in splitDays" :key="i" :class="split.class || false") {{ split.label }}

--- a/src/components/vue-cal/weekdays-headings.vue
+++ b/src/components/vue-cal/weekdays-headings.vue
@@ -13,10 +13,11 @@
       .vuecal__flex(column :key="vuecal.transitions ? `${i}-${heading.dayOfMonth}` : false")
         .vuecal__flex.weekday-label(grow)
           //- For small/xsmall option. 3 media queries also truncate weekdays.
-          span.full {{ heading.full }}
-          span.small {{ heading.small }}
-          span.xsmall {{ heading.xsmall }}
-          span(v-if="heading.dayOfMonth") &nbsp;{{ heading.dayOfMonth }}
+          slot(name="weekday-renderer" :heading="{ heading }")
+            span.full {{ heading.full }}
+            span.small {{ heading.small }}
+            span.xsmall {{ heading.xsmall }}
+            span(v-if="heading.dayOfMonth") &nbsp;{{ headings.dayOfMonth }}
         .vuecal__flex.vuecal__split-days-headers(
           v-if="vuecal.hasSplits && vuecal.stickySplitLabels"
           grow)

--- a/src/components/vue-cal/weekdays-headings.vue
+++ b/src/components/vue-cal/weekdays-headings.vue
@@ -13,7 +13,7 @@
       .vuecal__flex(column :key="vuecal.transitions ? `${i}-${heading.dayOfMonth}` : false")
         .vuecal__flex.weekday-label(grow)
           //- For small/xsmall option. 3 media queries also truncate weekdays.
-          slot(name="weekday-renderer" :heading="{ heading }")
+          slot(name="weekday-renderer" :heading="{ heading }" :view="{ view }" )
             span.full {{ heading.full }}
             span.small {{ heading.small }}
             span.xsmall {{ heading.xsmall }}

--- a/src/views/isolated-test-view.vue
+++ b/src/views/isolated-test-view.vue
@@ -3,14 +3,24 @@
 vue-cal(
   :selected-date="selectedDate"
   :events="events"
+  :hide-weekdays="[1,2,3,4,5]"
   editable-events
   style="min-height: 400px;max-height: 65vh")
+  template(v-slot:weekday-renderer="{ heading, view }")
+    table.myheaders(
+      v-if="view.view.id === 'week'")
+      tr.headingrow
+        td
+          span.dateCircle {{ (heading.heading.dayOfMonth) }}
+        td.headingcell
+          span.headingmonth {{ getMonth(heading.heading.date) }}
+          br
+          span.headingday {{ heading.heading.full }}
 </template>
 
 <script>
 import VueCal from '@/components/vue-cal'
 
-const now = new Date()
 export default {
   components: { VueCal },
   data: () => ({
@@ -30,11 +40,40 @@ export default {
   }),
 
   methods: {
+    getMonth (datestring) {
+      return datestring.toString().split(' ')[1]
+    },
+    bar (heading) {
+      return heading.heading.full
+    }
   }
 }
 </script>
 
 <style lang="scss">
-.v-application--wrap {min-height: 0;}
-footer {display: none !important;}
+
+  .dateCircle {
+    border: 1px solid black;
+    border-radius: 30px;
+    text-align:right;
+    margin-right:10px;
+    padding-right: 5px;
+    padding-left: 5px;
+  }
+  .myheaders {
+  }
+  .headingrow {
+  }
+  .headingcell {
+    text-align:left;
+  }
+  .headingmonth {
+    text-align: left;
+  }
+  .headingday {
+    text-align: left;
+  }
+
+  .v-application--wrap {min-height: 0;}
+  footer {display: none !important;}
 </style>

--- a/src/views/isolated-test-view.vue
+++ b/src/views/isolated-test-view.vue
@@ -3,77 +3,34 @@
 vue-cal(
   :selected-date="selectedDate"
   :events="events"
-  :hide-weekdays="[1,2,3,4,5]"
   editable-events
+  twelve-hour
   style="min-height: 400px;max-height: 65vh")
-  template(v-slot:weekday-renderer="{ heading, view }")
-    table.myheaders(
-      v-if="view.view.id === 'week'")
-      tr.headingrow
-        td
-          span.dateCircle {{ (heading.heading.dayOfMonth) }}
-        td.headingcell
-          span.headingmonth {{ getMonth(heading.heading.date) }}
-          br
-          span.headingday {{ heading.heading.full }}
 </template>
 
 <script>
 import VueCal from '@/components/vue-cal'
 
+const now = new Date()
 export default {
   components: { VueCal },
   data: () => ({
-    selectedDate: '2020-04-05',
+    selectedDate: now,
     events: [
-      // {
-      //   startDate: new Date(new Date(now).setHours(9, 0, 0, 0)),
-      //   endDate: new Date(new Date(now).setHours(12, 0, 0, 0)),
-      //   title: 'Event'
-      // },
       {
-        start: '2020-04-04 00:00',
-        end: '2020-04-05 08:00',
+        startDate: new Date(new Date(now).setHours(9, 0, 0, 0)),
+        endDate: new Date(new Date(now).setHours(12, 0, 0, 0)),
         title: 'Event'
       }
     ]
   }),
 
   methods: {
-    getMonth (datestring) {
-      return datestring.toString().split(' ')[1]
-    },
-    bar (heading) {
-      return heading.heading.full
-    }
   }
 }
 </script>
 
 <style lang="scss">
-
-  .dateCircle {
-    border: 1px solid black;
-    border-radius: 30px;
-    text-align:right;
-    margin-right:10px;
-    padding-right: 5px;
-    padding-left: 5px;
-  }
-  .myheaders {
-  }
-  .headingrow {
-  }
-  .headingcell {
-    text-align:left;
-  }
-  .headingmonth {
-    text-align: left;
-  }
-  .headingday {
-    text-align: left;
-  }
-
-  .v-application--wrap {min-height: 0;}
-  footer {display: none !important;}
+.v-application--wrap {min-height: 0;}
+footer {display: none !important;}
 </style>


### PR DESCRIPTION
Summary:
  Adds weekday-renderer slots for the week view to the calendar

  The customizations right now for the headers for the week views and more
  are pretty isolated; By giving the slot in, more rubust options will
  become open to the developer.
Test Plan:
  Generally Add the following to a calendar:
      >template(v-slot:weekday-renderer="{ headings }")
      >  span.full {{ '2019-10-11' + getRandomString() }}
      >  span.small {{ '2019-10-11' + getRandomString()}}
      >  span.xsmall {{ '2019-10-11' + getRandomString()}}
  And method,
      > getRandomString () {
      >   return (Math.floor(Math.random() * 10)) + ''
      > },

  Expected outcome is a few different appended numbers to the same date;

Thoughts:
  The other alternative for this is to have a slot for each `full`,
  `small`, `xsmall`. But I believe that it is better to let the
  programmer decide whether or not they would like to incorporate the
  dynamic effects of `hide` upon the resizing of the calendar. This will
  need to be incorporated into the docs and made a point as such for
  what extra options are available at the point this slot is encountered
  on the library's side.