### PR TITLE
Create segments for multiday events for displayed out of scope days

### DIFF
--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -466,7 +466,7 @@ export default {
             .filter(e => eventInRange(e, startDate, endDate))
             .map(e => {
               // If multiple-day events.
-              return e.start.substr(0, 10) === e.end.substr(0, 10) ? e : createEventSegments(e, startDate, endDate, this)
+              return e.start.substr(0, 10) === e.end.substr(0, 10) ? e : createEventSegments(e, firstCellDate, lastCellDate, this)
             })
         )
 


### PR DESCRIPTION
I have some multi day events that spread across 2 months, e.g.: start 31 dec 2019, end 3 jan 2020.

Currently, the segments are calculated only for days in the current month, but since the change that displayes events also on out of scope days, the code looks for segments for those days too, and an error is triggered: `TypeError: "event.segments[cell.formattedDate] is undefined"`. This is because the code is looking for an segment for 1st of Jan 2020 and 2nd of Jan 2020, but the event only has segments created for 31st of Dev 2019, and none for 1st or 2nd of Jan 2020, even though the cells are present in the view, and rendered.

The change I propose is to calculate segments for all the displyed days, so instead of: `createEventSegments(e, startDate, endDate, this)` we run: `createEventSegments(e, firstCellDate, lastCellDate, this)`.

With this change, I no longer have the error, and the events are displayed correctly.

In my project I have only the month view, so I don't know if this issue is reproducible on other views, but I don't think so, because I think only on month view you have days displayed that are not in current scope (to show full week at the begining and end).

