### PR TITLE
Add vuecal-cell-(viewId)-xxx class to cell

### DIFF
--- a/src/components/vue-cal/index.vue
+++ b/src/components/vue-cal/index.vue
@@ -95,6 +95,7 @@
                 :style="contentMinWidth ? `min-width: ${contentMinWidth}px` : ''")
                 vuecal-cell(
                   v-for="(cell, i) in viewCells"
+                  :class="cellClass(cell)"
                   :key="i"
                   :options="$props"
                   :edit-events="editEvents"
@@ -1004,6 +1005,33 @@ export default {
         style.innerHTML = `.vuecal__weekdays-headings,.vuecal__all-day {padding-right: ${scrollbarWidth}px}`
         document.head.appendChild(style)
       }
+    },
+
+    cellClass (cell) {
+      let cssClass = ''
+      switch (this.view.id) {
+        case 'years': {
+          cssClass = `vuecal-cell-${this.view.id}-${cell.startDate.getYear()}`
+          break
+        }
+        case 'year': {
+          cssClass = `vuecal-cell-${this.view.id}-${cell.startDate.getMonth()}`
+          break
+        }
+        case 'month': {
+          cssClass = `vuecal-cell-${this.view.id}-${cell.startDate.getDay()}`
+          break
+        }
+        case 'week': {
+          cssClass = `vuecal-cell-${this.view.id}-${cell.startDate.getDay()}`
+          break
+        }
+        case 'day': {
+          cssClass = `vuecal-cell-${this.view.id}-${cell.startDate.getDay()}`
+          break
+        }
+      }
+      return cssClass
     }
   },
 


### PR DESCRIPTION
Add class `vuecal-cell-(view.id)-(datePart)` to cell.

Goal is to allow styling of an entire column in month view.  For example Saturday will have a special background color.

```
<div class="vuecal__cell vuecal-cell-month-5">
    <div column="" tabindex="0" aria-label="4" class="vuecal__flex vuecal__cell-content">
           <div class="vuecal__cell-date">4</div><!----><!----><!----></div></div>
```