### PR TITLE
activeView validator

### DIFF
--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -201,7 +201,20 @@ export default {
   },
 
   props: {
-    activeView: { type: String, default: 'week' },
+    activeView: {
+      type: String,
+      default: 'week',
+      validator: function (view) {
+        const allowedViews = [
+          'day',
+          'week',
+          'month',
+          'year',
+          'years'
+        ];
+        return allowedViews.includes(view);
+      }
+    },
     // Only used if there are daySplits with minSplitWidth, to add the same height top spacer on time column.
     allDayBarHeight: { type: [String, Number], default: '25px' },
     cellClickHold: { type: Boolean, default: true },


### PR DESCRIPTION
This would have saved me some time today. I got a cryptic error message and couldn't figure out where it came from. Turns out I passed in `'week;'` instead of `'week'`. If this validator was in place it would have given an easier to resolve error message.

```js
computed: {
  activeView: function () {
    if (this.defaultView) {
      return this.defaultView;
    }
    if (this.aggregateView) {
      return 'month';
    }
    return 'week;'; // <-- This was the problem I had
  }
}
```