### PR TITLE
Support for earliestStart and latestEnd constraints.

### DIFF
--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -832,6 +832,12 @@ export default {
         event.endTimeMinutes = plusHalfSnapTime - (plusHalfSnapTime % this.snapToTime)
       }
 
+      // Apply constraints
+      const { latestEnd } = event.constraints || {}
+      if (latestEnd) {
+      event.endTimeMinutes = Math.min(event.endTimeMinutes, latestEnd.getHours() * 60 + latestEnd.getMinutes())
+      }
+
       if (segment) segment.endTimeMinutes = event.endTimeMinutes
 
       // Remove 1 second if time is 24:00.
@@ -915,8 +921,11 @@ export default {
         const dragFromBottom = start < timeAtCursor
         const { event } = dragCreateAnEvent
 
-        event.start = dragFromBottom ? start : timeAtCursor
-        event.end = dragFromBottom ? timeAtCursor : start
+        // Apply constraints
+        const { latestEnd, earliestStart } = event.constraints || {}
+
+        event.start = dragFromBottom ? start : (earliestStart ? new Date(Math.max(earliestStart.getTime(), timeAtCursor.getTime)) : timeAtCursor)
+        event.end = dragFromBottom ? (latestEnd ? new Date(Math.min(timeAtCursor.getTime(), latestEnd.getTime())) : timeAtCursor) : start
         event.startTimeMinutes = event.start.getHours() * 60 + event.start.getMinutes()
         event.endTimeMinutes = event.end.getHours() * 60 + event.end.getMinutes()
       }


### PR DESCRIPTION
Support for constraints on the start and end of an event while creating or resizing it by dragging. To use the application should in its event-create handler set a `constraints` property on the (returned) event. 
This property should be an object with:

- `earliestStart`, optional, the earliest allowed start Date for the event
- `latestEnd`, optional, the latest allowed end Date for the event

For example to restrict events to a maximum length of 90 minutes the `event-create` handler could be like:
```
addEvent (ev) {
  ev.constraints = {
    latestEnd: ev.start.addMinutes(90)
  }
  return ev
}