### PR TITLE
Dynamic background color for splits

### DIFF
--- a/src/vue-cal/cell.vue
+++ b/src/vue-cal/cell.vue
@@ -10,6 +10,7 @@ transition-group.vuecal__cell(
     :key="options.transitions ? `${view.id}-${data.content}-${i}` : i"
     :class="splitsCount && splitClasses(split)"
     :data-split="splitsCount ? split.id : false"
+    :style="{'background-color': splitColor(split)}"
     column
     tabindex="0"
     :aria-label="data.content"
@@ -101,6 +102,9 @@ export default {
         'vuecal__cell-split--highlighted': this.highlightedSplit === split.id,
         [split.class]: !!split.class
       }
+    },
+    splitColor (split) {
+      return split.color
     },
 
     checkCellOverlappingEvents () {


### PR DESCRIPTION
In the current implementation to define the background color for the split cells it is necessary to define astyle for it’s class on the CSS. 
I’ve found that this is not practical when the color is fetched from the back-end or need to change dynamically so I had to made this small change to be able to accomplish that.

Old behavior for setting the background color of a split:

```
In data..
splits: [
  { label: 'Whatever', class: 'split1' }
]
In CSS
.vuecal__body .split1 {background-color: rgba(226, 242, 253, 0.7);}

```
This PR:

```
splits: [
  { label: 'Whatever', color: 'rgba(226, 242, 253, 0.7)' }
]
```