### PR TITLE
Update documentation for default time step from 30 to 60

### DIFF
--- a/src/documentation/api.vue
+++ b/src/documentation/api.vue
@@ -55,7 +55,7 @@ div
     timeCellHeight:         [Number],          default: 40 // In pixels.
     timeFormat:             [String],          default: ''
     timeFrom:               [Number],          default: 0 // In minutes.
-    timeStep:               [Number],          default: 30 // In minutes.
+    timeStep:               [Number],          default: 60 // In minutes.
     timeTo:                 [Number],          default: 24 * 60 // In minutes.
     todayButton:            [Boolean],         default: false
     transitions:            [Boolean],         default: true
@@ -369,7 +369,7 @@ div
         By default it ends at 24:00.
     li
       code.mr2 timeStep
-      span.code [Number], default: 30
+      span.code [Number], default: 60
       p.
         If #[span.code time] is enabled, set the time increment in minutes.
     li


### PR DESCRIPTION
Currently, the default time step for the implementation is 60 and in the documentation is 30.
This PR updates the documentation to be inline with the implementation.

See https://github.com/antoniandre/vue-cal/blob/973bf2852decfb8d2cefa35695766aee860ad765/src/vue-cal/index.vue#L251 for the implementation value and https://antoniandre.github.io/vue-cal/#api for the documentation value currently

@antoniandre 