### PR TITLE
[#505] Fix weekly view start/end dates

### DIFF
--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -1600,7 +1600,7 @@ export default {
           const weekDays = this.weekDays
 
           cells = weekDays.map((cell, i) => {
-            const startDate = ud.addDays(firstDayOfWeek, this.startWeekOnSunday ? i - 1 : i)
+            const startDate = ud.addDays(firstDayOfWeek, i)
             const endDate = new Date(startDate)
             endDate.setHours(23, 59, 59, 0) // End at 23:59:59.
             const dayOfWeek = (startDate.getDay() || 7) - 1 // Day of the week from 0 to 6 with 6 = Sunday.

--- a/src/vue-cal/weekdays-headings.vue
+++ b/src/vue-cal/weekdays-headings.vue
@@ -53,7 +53,7 @@ export default {
 
       let todayFound = false
       const headings = this.weekDays.map((cell, i) => {
-        const date = this.utils.date.addDays(this.view.startDate, this.vuecal.startWeekOnSunday ? i - 1 : i)
+        const date = this.utils.date.addDays(this.view.startDate, i)
 
         return {
           hide: cell.hide,


### PR DESCRIPTION
`this.view` already takes into account start week on Sunday (https://github.com/antoniandre/vue-cal/blob/main/src/vue-cal/index.vue#L517).

These two lines were subtracting an extra day.

Fixes #505 