### PR TITLE
Bugfix/start week on sunday incorrect labels

### DIFF
--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -1600,7 +1600,7 @@ export default {
           const weekDays = this.weekDays
 
           cells = weekDays.map((cell, i) => {
-            const startDate = ud.addDays(firstDayOfWeek, this.startWeekOnSunday ? i - 1 : i)
+            const startDate = ud.addDays(firstDayOfWeek, this.startWeekOnSunday && this.hideWeekends ? i - 1 : i)
             const endDate = new Date(startDate)
             endDate.setHours(23, 59, 59, 0) // End at 23:59:59.
             const dayOfWeek = (startDate.getDay() || 7) - 1 // Day of the week from 0 to 6 with 6 = Sunday.

--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -1255,6 +1255,7 @@ export default {
   },
 
   mounted () {
+    console.log('vue-cal index mounted: https://github.com/chillburn/vue-cal.git#bugfix/start-week-on-sunday-incorrect-labels')
     const ud = this.utils.date
     const hasTouch = 'ontouchstart' in window
     const { resize, drag, create, delete: deletable, title } = this.editEvents

--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -1255,7 +1255,6 @@ export default {
   },
 
   mounted () {
-    console.log('vue-cal index mounted: https://github.com/chillburn/vue-cal.git#bugfix/start-week-on-sunday-incorrect-labels')
     const ud = this.utils.date
     const hasTouch = 'ontouchstart' in window
     const { resize, drag, create, delete: deletable, title } = this.editEvents

--- a/src/vue-cal/weekdays-headings.vue
+++ b/src/vue-cal/weekdays-headings.vue
@@ -53,7 +53,7 @@ export default {
 
       let todayFound = false
       const headings = this.weekDays.map((cell, i) => {
-        const date = this.utils.date.addDays(this.view.startDate, this.vuecal.startWeekOnSunday ? i - 1 : i)
+        const date = this.utils.date.addDays(this.view.startDate, this.vuecal.startWeekOnSunday && this.vuecal.hideWeekends ? i - 1 : i)
 
         return {
           hide: cell.hide,


### PR DESCRIPTION
Similar fix to https://github.com/antoniandre/vue-cal/pull/524 but this is for the main branch. Version 4.8.1

When startWeekOnSunday is set to true, the date labels are out by one day. 