### PR TITLE
Fix i18n issue with date format in custom title template

### DIFF
--- a/src/vue-cal/index.vue
+++ b/src/vue-cal/index.vue
@@ -366,17 +366,9 @@ export default {
         return
       }
 
-      if (this.locale === 'en') {
-        const texts = await import('./i18n/en.json')
-        this.texts = Object.assign({}, textsDefaults, texts)
-      }
-      else {
-        import(`./i18n/${locale}.json`)
-          .then(response => {
-            this.texts = Object.assign({}, textsDefaults, response.default)
-            this.utils.date.updateTexts(this.texts)
-          })
-      }
+      const texts = await import(`./i18n/${locale}.json`)
+      this.texts = Object.assign({}, textsDefaults, texts)
+      this.utils.date.updateTexts(this.texts)
     },
 
     /**


### PR DESCRIPTION
Hey Antoni!

This PR Fixes an issue which happens when:
- the default "en" locale is used
- and a custom "title template" is defined
- and "dddd MMMM" date format is used

Behaviour:
The custom month / day text is not displayed

Reproduce:
https://stackblitz.com/edit/vuecal-vite-vscdqg?file=src%2FApp.vue

I figured that the `this.utils.date.updateTexts(this.texts)` call was missing when the "en" was loaded, leaving the date format texts as default empty strings.